### PR TITLE
fix: press enter doesn't work in console

### DIFF
--- a/lib/PageAgent.js
+++ b/lib/PageAgent.js
@@ -60,9 +60,6 @@ extend(PageAgent.prototype, {
   _doGetResourceTree: function(params, done) {
     var cwd = this._debuggerClient.target.cwd;
     var filename = this._debuggerClient.target.filename;
-    if (!this._debuggerClient.isHostMachine) {
-        return done();
-    }
     async.waterfall(
       [
         this._resolveMainAppScript.bind(this, cwd, filename),


### PR DESCRIPTION
### Description

The changes in this pull request involve removing a conditional check that is no longer needed in the `_doGetResourceTree` function in the `PageAgent.js` file.

- Removed a conditional check related to the `_debuggerClient.isHostMachine` property within the `_doGetResourceTree` function.

These changes simplify the code by eliminating unnecessary conditional logic that is no longer required.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Remove an unnecessary conditional check in the _doGetResourceTree function to fix the issue where pressing enter does not work in the console.

Bug Fixes:
- Fix the issue where pressing enter does not work in the console by removing an unnecessary conditional check in the _doGetResourceTree function.

<!-- Generated by sourcery-ai[bot]: end summary -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced resource handling allows for improved functionality even when the debugger is not running on the host machine.
  
- **Bug Fixes**
	- Modified control flow ensures that resource tree resolution will occur consistently, improving reliability across different environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->